### PR TITLE
Add Native build type for ios template

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+
 plugins {
     kotlin("multiplatform")
     kotlin("native.cocoapods")
@@ -20,6 +22,10 @@ kotlin {
         framework {
             baseName = "core"
         }
+        xcodeConfigurationToNativeBuildType["Debug Staging"] = NativeBuildType.DEBUG
+        xcodeConfigurationToNativeBuildType["Debug Production"] = NativeBuildType.DEBUG
+        xcodeConfigurationToNativeBuildType["Release Staging"] = NativeBuildType.RELEASE
+        xcodeConfigurationToNativeBuildType["Release Production"] = NativeBuildType.RELEASE
     }
     
     sourceSets {


### PR DESCRIPTION

## What happened 👀

Add Native build type for iOS template

## Insight 📝

Fix build failing because cocoapods.

## Proof Of Work 📹

<img width="190" alt="Screen Shot 2022-09-22 at 14 00 17" src="https://user-images.githubusercontent.com/6356137/191679734-d8fb553c-40ea-45cf-9e5f-23469a2848ba.png">
