### PR TITLE
[Chore] Publish library to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to Github Packages
+
+on:
+  push:
+    branches:
+      - develop
+      - chore/publish-packages
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & publish to Github Packages
+    runs-on: macos-12
+    steps:
+      - name: Set up JAVA 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: ./gradlew assemble --stacktrace -PGITHUB_USER=${{ secrets.CURRENT_GITHUB_USER }} -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release library
+        run: ./gradlew core:publish -PGITHUB_USER=${{ secrets.CURRENT_GITHUB_USER }} -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - chore/publish-packages
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -25,11 +25,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Add KMM Packages
-        run: |
-          perl -i -p -e 'print "kotlin(\"multiplatform\").version(\"1.7.10\").apply(false)\n" if $. == 15' build.gradle.kts
-          perl -i -p -e 'print "id(\"com.android.library\").version(\"7.2.2\").apply(false)\n" if $. == 14' build.gradle.kts
-
       - name: Run Test
         run: ./gradlew test
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/nimblehq/jsonapi-kotlin/review_pull_request.yml?branch=develop)
+![GitHub Packages](https://img.shields.io/badge/version-0.1.0-blue)
+
 # JSON:API Kotlin
 
 Kotlin module for mapping JSON response, in the format of [JSON:API](https://jsonapi.org) to objects.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ docs:
   ```
   repositories {
      maven {
-         url = "https://maven.pkg.github.com/mohitrajput987/analytics-sdk"
+         name = "Github Packages"
+         url = uri("https://maven.pkg.github.com/nimblehq/jsonapi-kotlin")
          credentials {
              username = GITHUB_USER
              password = GITHUB_TOKEN

--- a/README.md
+++ b/README.md
@@ -6,80 +6,67 @@ Made specifically for Kotlin Multiplatform Mobile (KMM).
 
 ## Installation
 
-### Git Submodule
+Following [Working with the Gradle registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry)
+docs:
 
-1. Add this library as a submodule of your project.
+- Add GitHub Packages repository at the root project level.
 
-```
-git submodule add git@github.com:nimblehq/jsonapi-kotlin.git
-```
+  ```
+  repositories {
+     maven {
+         url = "https://maven.pkg.github.com/mohitrajput987/analytics-sdk"
+         credentials {
+             username = GITHUB_USER
+             password = GITHUB_TOKEN
+         }
+     }
+  }
+  ```
 
-### Manually
+  - GITHUB_USER: the developer's GitHub user to access GitHub Packages.
+  - GITHUB_TOKEN: the developer's GitHub personal access token with at least `packages:read` permission.
 
-1. Clone the repository
+- Open `build.gradle.kts` of `shared` module, or any KMM module that will use the library.
 
-```
-git clone git@github.com:nimblehq/jsonapi-kotlin.git
-```
-
-2. Copy the cloned folder to the `root` of your project.
+  ```
+  kotlin {
+      sourceSets {
+          val commonMain by getting {
+              dependencies {
+                  implementation("co.nimblehq.jsonapi:core:${LATEST_VERSION}")
+              }
+          }
+          ...
+      }
+      ...
+  }
+  ```
 
 ## Usage
 
-Open `root` `settings.gradle.kts` and add the library as an include.
+- Use with `kotlinx.serialization.json.Json`. Call `decodeFromJsonApiString` to map string to object.
 
-```
-rootProject.name = "YourApp"
-include(":androidApp")
-include(":shared")
-// .. Add this line
-include(":nimble-jsonapi-kotlin:core")
-```
-
-### Add Dependency to `shared` Module
-
-Open `build.gradle.kts` of `shared` module, or any KMM module that will use the library.
-
-```
-sourceSets {
-  val commonMain by getting {
-      dependencies {
-          // ...
-          // Add this line
-            implementation(project(":jsonapi-kotlin:core"))
-        }
-    }
-  // ...
-}
-```
-
-### Use with `kotlinx.serialization.json.Json`
-
-Call `decodeFromJsonApiString` to map string to object.
-
-```
-@Serializable
-data class ExampleModel(val title: String)
-val body = """
-{
-  "data": {
-    "type": "articles",
-    "id": "1",
-    "attributes": {
-      "title": "JSON:API paints my bikeshed!"
+  ```
+  @Serializable
+  data class ExampleModel(val title: String)
+  val body = """
+  {
+    "data": {
+      "type": "articles",
+      "id": "1",
+      "attributes": {
+        "title": "JSON:API paints my bikeshed!"
+      }
     }
   }
-}
-"""
-val json = Json {
-     prettyPrint = true
-     isLenient = true
-     ignoreUnknownKeys = true
- }
-val data = JsonApi(json).decodeFromJsonApiString<ExampleModel>(body)
-```
-
-For installation example, see this [commit](https://github.com/suho/kmm-ic/pull/89/commits/010631cd00144edecfcc42f3a057c0294fa5571a).
+  """
+  val json = Json {
+       prettyPrint = true
+       isLenient = true
+       ignoreUnknownKeys = true
+   }
+  val data = JsonApi(json).decodeFromJsonApiString<ExampleModel>(body)
+  ```
 
 ## Features
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,8 @@ buildscript {
 }
 
 plugins {
-    //trick: for the same plugin versions in all sub-modules
-//    id("com.android.library").version("7.2.2").apply(false)
-//    kotlin("multiplatform").version("1.7.10").apply(false)
+    id("com.android.library").version("7.2.2").apply(false)
+    kotlin("multiplatform").version("1.7.10").apply(false)
 }
 
 tasks.register("clean", Delete::class) {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,33 +1,22 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
-
 plugins {
     kotlin("multiplatform")
-    kotlin("native.cocoapods")
     id("com.android.library")
     kotlin("plugin.serialization")
     id("kotlinx-serialization")
+    id("maven-publish")
 }
 
+group = "co.nimblehq.jsonapi"
+version = "0.1.0"
+
 kotlin {
-    android()
+    android {
+        publishLibraryVariants("release", "debug")
+    }
     iosX64()
     iosArm64()
     iosSimulatorArm64()
 
-    cocoapods {
-        summary = "Some description for the Shared Module"
-        homepage = "Link to the Shared Module homepage"
-        version = "1.0"
-        ios.deploymentTarget = "14.1"
-        framework {
-            baseName = "core"
-        }
-        xcodeConfigurationToNativeBuildType["Debug Staging"] = NativeBuildType.DEBUG
-        xcodeConfigurationToNativeBuildType["Debug Production"] = NativeBuildType.DEBUG
-        xcodeConfigurationToNativeBuildType["Release Staging"] = NativeBuildType.RELEASE
-        xcodeConfigurationToNativeBuildType["Release Production"] = NativeBuildType.RELEASE
-    }
-    
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -60,3 +60,15 @@ android {
         targetSdk = 32
     }
 }
+
+publishing {
+    repositories {
+        maven {
+            setUrl("https://maven.pkg.github.com/nimblehq/jsonapi-kotlin")
+            credentials {
+                username = (System.getenv("GITHUB_USER") ?: project.properties["GITHUB_USER"])?.toString()
+                password = (System.getenv("GITHUB_TOKEN") ?: project.properties["GITHUB_TOKEN"])?.toString()
+            }
+        }
+    }
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -12,6 +12,7 @@ version = "0.1.0"
 kotlin {
     android {
         publishLibraryVariants("release", "debug")
+        publishLibraryVariantsGroupedByFlavor = true
     }
     iosX64()
     iosArm64()


### PR DESCRIPTION
## What happened 👀

- Published the library GitHub Packages https://github.com/nimblehq/jsonapi-kotlin/packages.

## Insight 📝

- We need to adjust the project to optimize it as a KMM lib, nice articles are https://kotlinlang.org/docs/multiplatform-publish-lib.html and https://dev.to/kotlin/how-to-build-and-publish-a-kotlin-multiplatform-library-creating-your-first-library-1bp8.

### Publish to local Maven
- To test the lib packages, we can try to publish it to `Maven Local` first (offline):
  - Adding plugin `id("maven-publish")`, `group`, and `version` info.
  - Running `./gradlew publishToMavenLocal` to publish to local.
  - Using `mavenLocal()` as a repository to import the lib on local.

<img width="1398" alt="image" src="https://user-images.githubusercontent.com/16315358/208806612-ca2bcd8d-a315-4fd1-abe6-ba3d0f9a793d.png">


### Publish to online repositores

- There are some options are Jitpack, Maven Central, GitHub Packages, etc. While [Jitpack does not support KMM for iOS builds yet](https://github.com/jitpack/jitpack.io/issues/3853) ([failure logs](https://jitpack.io/com/github/nimblehq/jsonapi-kotlin/chore~publish-to-jitpack-6efd847ec6-1/build.log)), [Maven Central requires a complex account registration](https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/#overview) flow, so GitHub Packages is a good choice, let's try 💪 
- To publish the lib packages to the GitHub Packages, we need to create a new workflow publish to build (`./gradlew assemble`) and publish (`./gradlew core:publish`) the lib.

## Proof Of Work 📹

GitHub Actions: https://github.com/nimblehq/jsonapi-kotlin/actions/runs/3746400497
The lib packages have been published here https://github.com/nimblehq/jsonapi-kotlin/packages :tada:

<img width="1453" alt="image" src="https://user-images.githubusercontent.com/16315358/208806119-dbefa28c-723f-4556-a49d-03a7a028b759.png">

<img width="1343" alt="image" src="https://user-images.githubusercontent.com/16315358/208806149-e8a54534-ab3e-4980-807d-4118151abcd5.png">
